### PR TITLE
Bug fix: UndirectedGraph does not flag up is_weighted when the edge list contains the weight.

### DIFF
--- a/src/NEMtropy/graph_classes.py
+++ b/src/NEMtropy/graph_classes.py
@@ -166,10 +166,12 @@ class UndirectedGraph:
                         self.strength_sequence,
                         self.nodes_dict,
                     ) = nef.edgelist_from_edgelist_undirected(edgelist)
+                    self.is_weighted = True
+                    
                 self.n_nodes = len(self.dseq)
                 self.n_edges = np.sum(self.dseq)/2
                 self.is_initialized = True
-                self.is_weighted = True
+                
 
         elif degree_sequence is not None:
             if not isinstance(degree_sequence, (list, np.ndarray)):

--- a/src/NEMtropy/graph_classes.py
+++ b/src/NEMtropy/graph_classes.py
@@ -159,7 +159,7 @@ class UndirectedGraph:
                         self.dseq,
                         self.nodes_dict,
                     ) = nef.edgelist_from_edgelist_undirected(edgelist)
-                else:
+                else: # when the edge list contains edge weights
                     (
                         self.edgelist,
                         self.dseq,
@@ -169,6 +169,7 @@ class UndirectedGraph:
                 self.n_nodes = len(self.dseq)
                 self.n_edges = np.sum(self.dseq)/2
                 self.is_initialized = True
+                self.is_weighted = True
 
         elif degree_sequence is not None:
             if not isinstance(degree_sequence, (list, np.ndarray)):


### PR DESCRIPTION
This PR is to fix a bug of UndirectedGraph object. Namely, when giving an edge list with weights, the flag `is_weighted` remains "False".  The following code can reproduce the error. 

```python
import numpy as np
import networkx as nx
from NEMtropy import UndirectedGraph
from scipy import sparse

G = nx.karate_club_graph()
A = nx.adjacency_matrix(G)
labels = np.unique([d[1]['club'] for d in G.nodes(data=True)], return_inverse=True)[1]

src, trg, weights = sparse.find(A)
edgelist = np.vstack([src, trg, weights]).T

graph = UndirectedGraph(edgelist = edgelist)
graph.is_weighted # False
```

To fix this, I added one line to flag up the weight. See the diff of my edit. 