### PR TITLE
Numpy compatibility issue

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"
@@ -21,7 +24,6 @@ sphinx:
   # builder: "dirhtml"
   # Fail on all warnings to avoid broken references
   # fail_on_warning: true
-
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:
 #   - pdf

--- a/src/NEMtropy/models_functions.py
+++ b/src/NEMtropy/models_functions.py
@@ -2836,7 +2836,7 @@ def iterative_dcm_exp_2(theta, args):
     tmp = np.concatenate((k_out, k_in))
     ff = -np.log(
         np.array(
-            [tmp[i] / f[i] if tmp[i] != 0 else -np.infty for i in range(2 * n)]
+            [tmp[i] / f[i] if tmp[i] != 0 else -np.inf for i in range(2 * n)]
         )
     )
     # ff = -np.log(tmp/f)
@@ -3224,8 +3224,8 @@ def linsearch_fun_DCM_exp_fixed(xx):
                 and kk < 50):
             alfa *= beta
             kk += 1
-            cond = np.linalg.norm(alfa*dx[dx != np.infty], ord=2) < \
-                np.linalg.norm(dx_old[dx_old != np.infty], ord=2)
+            cond = np.linalg.norm(alfa*dx[dx != np.inf], ord=2) < \
+                np.linalg.norm(dx_old[dx_old != np.inf], ord=2)
     return alfa
 
 # DECM exponential functions
@@ -3808,8 +3808,8 @@ def linsearch_fun_DECM_exp_fixed(xx):
               and kk < 50):
             alfa *= beta
             kk += 1
-            cond = np.linalg.norm(alfa*dx[dx != np.infty], ord=2) < \
-                np.linalg.norm(dx_old[dx_old != np.infty], ord=2)
+            cond = np.linalg.norm(alfa*dx[dx != np.inf], ord=2) < \
+                np.linalg.norm(dx_old[dx_old != np.inf], ord=2)
 
     return alfa
 

--- a/src/NEMtropy/solver_functions.py
+++ b/src/NEMtropy/solver_functions.py
@@ -208,8 +208,8 @@ def solver(
             dx = f - x
             # TODO: hotfix to compute dx in infty cases
             for i in range(len(x)):
-                if x[i] == np.infty:
-                    dx[i] = np.infty
+                if x[i] == np.inf:
+                    dx[i] = np.inf
         toc_dx += time.time() - tic
 
         # backtraking line search


### PR DESCRIPTION
# Issue 

Nemtropy has a compatibility issue with numpy 2.0+ where np.infty has been removed from the API. See the following error messge: 

```
    778     raise AttributeError(__former_attrs__[attr], name=None)
    780 if attr in __expired_attributes__:
--> 781     raise AttributeError(
    782         f"`np.{attr}` was removed in the NumPy 2.0 release. "
    783         f"{__expired_attributes__[attr]}",
    784         name=None
    785     )
    787 if attr == "chararray":
    788     warnings.warn(
    789         "`np.chararray` is deprecated and will be removed from "
    790         "the main namespace in the future. Use an array with a string "
    791         "or bytes dtype instead.", DeprecationWarning, stacklevel=2)

AttributeError: `np.infty` was removed in the NumPy 2.0 release. Use `np.inf` instead.
```
The code has been updated to use np.inf instead, which is the recommended replacement and maintains backward compatibility with earlier NumPy versions.

All instances of np.infty in the codebase have been replaced with np.inf. 